### PR TITLE
[feat] Spring AOP 기반 DB Switch 기능 구현 (#7)

### DIFF
--- a/src/main/java/com/example/demo/config/ReplicationRoutingDataSource.java
+++ b/src/main/java/com/example/demo/config/ReplicationRoutingDataSource.java
@@ -1,5 +1,6 @@
 package com.example.demo.config;
 
+import com.example.demo.config.aop.DataSourceContextHolder;
 import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 
 import static org.springframework.transaction.support.TransactionSynchronizationManager.isCurrentTransactionReadOnly;
@@ -8,7 +9,13 @@ public class ReplicationRoutingDataSource extends AbstractRoutingDataSource {
 
     @Override
     protected Object determineCurrentLookupKey() {
-        // 현재 트랜잭션이 읽기 전용인 경우 Reader DB, 그렇지 않으면 Writer DB로 라우팅
+        // 컨텍스트에 데이터 소스 키가 설정되어 있으면 그 값을 사용
+        String dataSourceKey = DataSourceContextHolder.getDataSourceKey();
+        if (dataSourceKey != null) {
+            return dataSourceKey;
+        }
+
+        // 그렇지 않으면 트랜잭션 읽기 전용 여부에 따라 기본적으로 라우팅
         return isCurrentTransactionReadOnly() ? "reader" : "writer";
     }
 }

--- a/src/main/java/com/example/demo/config/aop/DataSourceAspect.java
+++ b/src/main/java/com/example/demo/config/aop/DataSourceAspect.java
@@ -1,0 +1,21 @@
+package com.example.demo.config.aop;
+
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class DataSourceAspect {
+
+    @Before("@annotation(com.example.demo.config.aop.WriteToReaderDB)")
+    public void setReaderDataSource() {
+        DataSourceContextHolder.setDataSourceKey("reader");
+    }
+
+    @After("@annotation(com.example.demo.config.aop.WriteToReaderDB)")
+    public void clearDataSource() {
+        DataSourceContextHolder.clearDataSourceKey();
+    }
+}

--- a/src/main/java/com/example/demo/config/aop/DataSourceContextHolder.java
+++ b/src/main/java/com/example/demo/config/aop/DataSourceContextHolder.java
@@ -1,0 +1,25 @@
+package com.example.demo.config.aop;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DataSourceContextHolder {
+
+    private static final ThreadLocal<String> CONTEXT = new ThreadLocal<>();
+
+    public static void setDataSourceKey(String key) {
+        log.info("Switch DataSource to {}", key);
+        CONTEXT.set(key);
+    }
+
+    public static String getDataSourceKey() {
+        return CONTEXT.get();
+    }
+
+    public static void clearDataSourceKey() {
+        CONTEXT.remove();
+    }
+}

--- a/src/main/java/com/example/demo/config/aop/WriteToReaderDB.java
+++ b/src/main/java/com/example/demo/config/aop/WriteToReaderDB.java
@@ -1,0 +1,11 @@
+package com.example.demo.config.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WriteToReaderDB {
+}

--- a/src/main/java/com/example/demo/service/MemberService.java
+++ b/src/main/java/com/example/demo/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.example.demo.service;
 
+import com.example.demo.config.aop.WriteToReaderDB;
 import com.example.demo.entity.Member;
 import com.example.demo.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,5 +21,11 @@ public class MemberService {
     @Transactional(readOnly = true)
     public Member findById(Long id) {
         return memberRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("해당 회원이 없습니다. id=" + id));
+    }
+
+    @WriteToReaderDB
+    @Transactional
+    public Long saveToReaderDB(Member member) {
+        return memberRepository.save(member).getId();
     }
 }

--- a/src/test/java/com/example/demo/service/MemberServiceTest.java
+++ b/src/test/java/com/example/demo/service/MemberServiceTest.java
@@ -26,4 +26,19 @@ class MemberServiceTest {
             memberService.findById(id);
         }).isInstanceOf(IllegalArgumentException.class);
     }
+
+    @DisplayName("메서드에 @WriteToReaderDB 어노테이션이 붙으면 readerDB로 라우팅되어야 한다.")
+    @Test
+    void writeToReaderDbTest() {
+        // @WriteToReaderDB -> readerDB로 라우팅하여 데이터 생성
+        Member member = Member.of("name", "email");
+        Long id = memberService.saveToReaderDB(member);
+
+        // @WriteToReaderDB -> readerDB로 라우팅하여 데이터 조회
+        Member foundMember = memberService.findById(id);
+
+        assertThat(foundMember.getId()).isEqualTo(id);
+        assertThat(foundMember.getName()).isEqualTo("name");
+        assertThat(foundMember.getEmail()).isEqualTo("email");
+    }
 }


### PR DESCRIPTION
# #️⃣ 연관 이슈

> - #7

# 📝 작업 내용

> AOP 기반으로 Service의 특정 메서드가 writerDB가 아니라 readerDB에 write할 수 있는 연산을 추가하여 보다 세밀한 DB 라우팅을 실현했습니다.

~~~java
@WriteToReaderDB
@Transactional
public Long saveToReaderDB(Member member) {
    return memberRepository.save(member).getId();
}

// 테스트 코드
@DisplayName("메서드에 @WriteToReaderDB 어노테이션이 붙으면 항상 readerDB로 라우팅되어야 한다.")
@Test
void writeToReaderDbTest() {
    Member member = Member.of("name", "email");
    Long id = memberService.saveToReaderDB(member);

    Member foundMember = memberService.findById(id);

    assertThat(foundMember.getId()).isEqualTo(id);
    assertThat(foundMember.getName()).isEqualTo("name");
    assertThat(foundMember.getEmail()).isEqualTo("email");
}
~~~

<img width="695" alt="image" src="https://github.com/user-attachments/assets/3170a449-16ce-4f0f-a880-d81cd9ce1033">

실제로 readerDB에 쓰기 연산을 가하는 것을 테스트코드를 통해 검증하였습니다. 

## 참고 이미지 및 자료

https://hyunwook.dev/206

# 💬 리뷰 요구사항


